### PR TITLE
Allow role user to specify logpath for ssh jails

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,4 @@ fail2ban_config_destemail: root@localhost
 # Jails
 fail2ban_config_jail_ssh_enabled: yes
 fail2ban_config_jail_sshddos_enabled: yes
+fail2ban_config_jail_auth_log_path: /var/log/auth.log

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -20,7 +20,7 @@ destemail = {{ fail2ban_config_destemail }}
 enabled  = {{ fail2ban_config_jail_ssh_enabled }}
 port     = ssh
 filter   = sshd
-logpath  = /var/log/auth.log
+logpath  = {{ fail2ban_config_jail_auth_log_path }}
 
 
 [ssh-ddos]
@@ -28,4 +28,4 @@ logpath  = /var/log/auth.log
 enabled  = {{ fail2ban_config_jail_sshddos_enabled }}
 port     = ssh
 filter   = sshd-ddos
-logpath  = /var/log/auth.log
+logpath  = {{ fail2ban_config_jail_auth_log_path }}


### PR DESCRIPTION
This PR introduces a configuration variable to allow users to specify a different logpath for the local SSH jails.

I'm running this role on CentOS (Linux release 7.3.1611 (Core)) and I have no `/var/log/auth.log`. However, the default logpath for the ssh jails works fine (`/var/log/secure`), but if `/var/log/auth.log` ends up as the logpath in `/etc/fail2ban/jail.local` then the service won't start.